### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -79,7 +79,7 @@ async def fetch_json(
         logger.error(f"Client error for {url}: {e}")
         raise TransportAPIError(f"Network error: {e}")
     except Exception as e:
-        logger.error(f"Unexpected error for {url}: {e}")
+        logger.error(f"Unexpected error during fetch: {e}")
         raise TransportAPIError(f"Unexpected error: {e}")
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/7](https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/7)

To fix the problem, we should avoid logging sensitive data such as user-supplied latitude and longitude (or any user-supplied query parameters) in error messages. Specifically, in `core/base.py`, the log message on line 82 should be changed to avoid including the full URL (which may contain sensitive query parameters). Instead, we can log only the base URL (without query parameters) or a generic message, and optionally include the exception message. This change should be made only to the log message on line 82; other log messages that do not include sensitive data can remain unchanged. No new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
