### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/tools/ch.py
+++ b/tools/ch.py
@@ -130,7 +130,7 @@ def register_ch_tools(mcp):
             params["distance"] = distance
 
         try:
-            logger.info(f"🇨🇭 Finding stations near: {latitude}, {longitude}")
+            logger.info("🇨🇭 Finding stations near provided coordinates")
             return await fetch_json(f"{CH_BASE_URL}/locations", params)
         except TransportAPIError as e:
             logger.error(f"CH nearby stations search failed: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/8](https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/8)

To fix the problem, we should avoid logging sensitive location data (latitude and longitude) in clear text. The best way is to either remove these values from the log message or replace them with a generic placeholder that does not expose the actual coordinates. This preserves the log's usefulness for tracking function calls without leaking private information. Specifically, in `tools/ch.py`, line 133 should be changed so that the log message does not include the values of `latitude` and `longitude`. No new imports or methods are needed; only the log statement needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
