### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text logging of sensitive information

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -73,10 +73,10 @@ async def fetch_json(
                     raise TransportAPIError(f"Invalid JSON response: {e}")
 
     except asyncio.TimeoutError:
-        logger.error(f"Request timeout for {url}")
+        logger.error("Request timeout for API endpoint")
         raise TransportAPIError(f"Request timeout after {timeout} seconds")
     except aiohttp.ClientError as e:
-        logger.error(f"Client error for {url}: {e}")
+        logger.error(f"Client error during API request: {e}")
         raise TransportAPIError(f"Network error: {e}")
     except Exception as e:
         logger.error(f"Unexpected error during fetch: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/6](https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/6)

To fix the problem, we should avoid logging the full URL (which may contain sensitive query parameters) in error messages. Instead, log only the endpoint path or a generic message, and avoid including user-provided data such as latitude and longitude. Specifically, in the error logging statements in `fetch_json`, replace instances of `logger.error(f"Client error for {url}: {e}")` and similar with a message that does not include the full URL or sensitive parameters. For context, we can log the endpoint path (e.g., `/locations`) or a generic identifier, but not the full query string. This change should be made in `core/base.py` in the error handling blocks of `fetch_json`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
