### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/core/base.py
+++ b/core/base.py
@@ -69,7 +69,7 @@ async def fetch_json(
                     logger.debug(f"Successfully fetched data from {url}")
                     return data
                 except Exception as e:
-                    logger.error(f"Failed to parse JSON from {url}: {e}")
+                    logger.error(f"Failed to parse JSON response: {e}")
                     raise TransportAPIError(f"Invalid JSON response: {e}")
 
     except asyncio.TimeoutError:


### PR DESCRIPTION
Potential fix for [https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/4](https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/4)

To fix the problem, we should avoid logging the full URL (which contains sensitive query parameters) in error messages. Instead, log only the endpoint path or a generic message, and optionally include non-sensitive context (such as the HTTP status code or exception message). Specifically, in `core/base.py`, line 72 should be changed to avoid logging the full URL. For example, log only the endpoint (without query parameters) or a generic error message. No additional imports are needed; only the log message needs to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
