### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text logging of sensitive information

### DIFF
--- a/tools/vbb.py
+++ b/tools/vbb.py
@@ -273,7 +273,7 @@ def register_vbb_tools(mcp):
             params["distance"] = int(distance)
 
         try:
-            logger.info("Finding VBB stations near: lat=%s, lon=%s", latitude, longitude)
+            logger.info("Finding VBB stations near requested coordinates")
             return await fetch_json(f"{VBB_BASE_URL}/locations/nearby", params)
         except TransportAPIError as e:
             logger.error("VBB nearby stations search failed: %s", e)


### PR DESCRIPTION
Potential fix for [https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/10](https://github.com/mirodn/mcp-server-public-transport/security/code-scanning/10)

In general, to fix clear-text logging of sensitive information, either stop logging the sensitive value entirely, or sufficiently redact/aggregate it so that it can’t be tied back to an individual or precise location, while still giving operators enough context for troubleshooting.

For this case, the simplest and safest fix that does not change functionality is to adjust the `logger.info` call in `vbb_nearby_stations` (line 276) so it no longer includes the actual `latitude` and `longitude` values. We can keep a generic message like “Finding VBB stations near requested coordinates” or similar. This preserves logging (for flow tracing) without exposing private coordinates. No new imports or helper functions are needed; we only change the log message string and remove use of the tainted variables in that call.

Concretely:
- In `tools/vbb.py`, inside `vbb_nearby_stations`, replace:
  - `logger.info("Finding VBB stations near: lat=%s, lon=%s", latitude, longitude)`
- With a non-sensitive log, for example:
  - `logger.info("Finding VBB stations near requested coordinates")`

All other behavior (building `params`, calling `fetch_json`, error handling) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
