### PR TITLE
Add Portugal provider (Lisbon + Porto) via Transitous

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Currently, it integrates APIs from UK, Switzerland, Norway, Belgium, Berlin/Bran
 
 > Portugal coverage is scoped to the Lisbon and Porto metro areas (Metro Lisboa, Carris, Carris Metropolitana, CP suburban; Metro do Porto, STCP) via [Transitous](https://transitous.org), a free MOTIS instance over ingested GTFS feeds. No API key required.
 
+#### Attribution (Transitous)
+
+Lisbon/Porto data is served by [Transitous](https://transitous.org), a volunteer-run,
+best-effort service (limited hosting, no availability or accuracy guarantees). Keep the
+Transitous attribution visible when showing this data to users; underlying feeds, including
+OpenStreetMap, are listed at [transitous.org/sources](https://transitous.org/sources/).
+
+Follow the [Transitous usage policy](https://transitous.org/api/): modest request volume,
+an identifying `User-Agent`, non-commercial / open-source use only.
+
 ## Setup
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An MCP Server providing real-time public transport data across Europe.
 ## About
 
 mcp-server-public-transport is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction)-compatible local server that provides access to public transport data across Europe.
-Currently, it integrates APIs from UK, Switzerland, Norway, Belgium and Berlin/Brandenburg, allowing you to retrieve train connections, live departures, and bus locations.
+Currently, it integrates APIs from UK, Switzerland, Norway, Belgium, Berlin/Brandenburg and Portugal (Lisbon + Porto), allowing you to retrieve train connections, live departures, and bus locations.
 
 ## Feature Implementation Status
 
@@ -24,6 +24,7 @@ Currently, it integrates APIs from UK, Switzerland, Norway, Belgium and Berlin/B
 | **Belgium**           | [https://api.irail.be](https://api.irail.be)                      | ✅     |
 | **Norway**            | [https://api.entur.io](https://api.entur.io)                     | ✅    |
 | **Berlin/Brandenburg**| [https://v6.vbb.transport.rest](https://v6.vbb.transport.rest)   | ✅    |
+| **Portugal** (Lisbon + Porto) | [https://api.transitous.org](https://api.transitous.org)      | ✅    |
 
 ### Features by Country
 
@@ -51,6 +52,13 @@ Currently, it integrates APIs from UK, Switzerland, Norway, Belgium and Berlin/B
 | Live Arrivals | `/stops/:id/arrivals` | ✅ |
 | Journey Planning | `/journeys` | ✅ |
 | Nearby Stations | `/locations/nearby` | ✅ |
+| **Portugal** (Lisbon + Porto) | | |
+| Station Lookup | `/geocode` | ✅ |
+| Search Connections | `/plan` | ✅ |
+| Departure Board | `/stoptimes` | ✅ |
+| Nearby Stations | `/reverse-geocode` | ✅ |
+
+> Portugal coverage is scoped to the Lisbon and Porto metro areas (Metro Lisboa, Carris, Carris Metropolitana, CP suburban; Metro do Porto, STCP) via [Transitous](https://transitous.org), a free MOTIS instance over ingested GTFS feeds. No API key required.
 
 ## Setup
 

--- a/config.py
+++ b/config.py
@@ -21,6 +21,10 @@ BE_BASE_URL = "https://api.irail.be"
 # Berlin/Brandenburg VBB API (v6.vbb.transport.rest)
 VBB_BASE_URL = "https://v6.vbb.transport.rest"
 
+# Portugal via Transitous (MOTIS routing over ingested GTFS feeds)
+# scoped to Lisbon + Porto metro areas, no auth
+PT_BASE_URL = "https://api.transitous.org/api/v1"
+
 # Server settings
 SERVER_NAME = "MCP Public Transport Server"
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")

--- a/core/base.py
+++ b/core/base.py
@@ -35,7 +35,12 @@ async def get_session() -> aiohttp.ClientSession:
             _session = aiohttp.ClientSession(
                 timeout=aiohttp.ClientTimeout(total=30),
                 headers={
-                    "User-Agent": "MCP-Public-Transport-Server/1.0",
+                    # Identify the client with contact info. Some upstreams (e.g.
+                    # Transitous) require an identifying User-Agent in their usage policy.
+                    "User-Agent": (
+                        "MCP-Public-Transport-Server/1.0 "
+                        "(+https://github.com/mirodn/mcp-server-public-transport)"
+                    ),
                 },
             )
         return _session

--- a/server.py
+++ b/server.py
@@ -11,6 +11,7 @@ from tools.uk import register_uk_tools
 from tools.be import register_be_tools
 from tools.no import register_no_tools
 from tools.vbb import register_vbb_tools
+from tools.pt import register_pt_tools
 from config import SERVER_NAME
 
 logger = logging.getLogger(__name__)
@@ -52,6 +53,7 @@ def main():
     be_tools = register_be_tools(mcp)
     no_tools = register_no_tools(mcp)
     vbb_tools = register_vbb_tools(mcp)
+    pt_tools = register_pt_tools(mcp)
 
     uk_app_id = os.getenv("UK_TRANSPORT_APP_ID")
     uk_api_key = os.getenv("UK_TRANSPORT_API_KEY")
@@ -64,9 +66,10 @@ def main():
         else:
             logger.info("UK tools disabled via --disable-uk")
 
-    total = len(ch_tools) + len(uk_tools) + len(be_tools) + len(no_tools) + len(vbb_tools)
+    total = len(ch_tools) + len(uk_tools) + len(be_tools) + len(no_tools) + len(vbb_tools) + len(pt_tools)
     logger.info(f"{SERVER_NAME} initialized with {total} tools "
-                f"(CH: {len(ch_tools)}, NO: {len(no_tools)}, UK: {len(uk_tools)}, BE: {len(be_tools)}, VBB: {len(vbb_tools)})")
+                f"(CH: {len(ch_tools)}, NO: {len(no_tools)}, UK: {len(uk_tools)}, BE: {len(be_tools)}, "
+                f"VBB: {len(vbb_tools)}, PT: {len(pt_tools)})")
 
     # Start transport
     if args.transport == "stdio":

--- a/test/test_pt.py
+++ b/test/test_pt.py
@@ -1,0 +1,56 @@
+import pytest
+from fastmcp import FastMCP
+from tools.pt import register_pt_tools
+
+@pytest.fixture
+def mcp():
+    server = FastMCP("test-pt")
+    register_pt_tools(server)
+    return server
+
+# geocode/reverse-geocode return a list, plan/stoptimes return a dict.
+# the tools filter geocode hits down to PT, so feed a mixed list to check scoping.
+GEOCODE = [
+    {"type": "STOP", "id": "pt-Metro-Lisboa_MP", "name": "Marquês de Pombal", "country": "PT"},
+    {"type": "STOP", "id": "it-trenitalia_x", "name": "Elmas Aeroporto", "country": "IT"},
+]
+
+@pytest.fixture(autouse=True)
+def mock_fetch_json(monkeypatch):
+    async def dummy(url, params):
+        if "geocode" in url:
+            return GEOCODE
+        return {"dummy": True}
+    monkeypatch.setattr("tools.pt.fetch_json", dummy)
+    return dummy
+
+async def get_tool(mcp, name):
+    tools = await mcp._list_tools()
+    return next(t for t in tools if t.name == name)
+
+class TestPTTools:
+
+    @pytest.mark.unit
+    async def test_pt_search_stations(self, mcp):
+        fn = await get_tool(mcp, "pt_search_stations")
+        result = await fn.fn("Marques de Pombal")
+        # non-PT hits are dropped
+        assert result == [GEOCODE[0]]
+
+    @pytest.mark.unit
+    async def test_pt_search_connections(self, mcp):
+        fn = await get_tool(mcp, "pt_search_connections")
+        result = await fn.fn("pt-Metro-Lisboa_MP", "pt-Metro-Lisboa_BC", limit=3)
+        assert result == {"dummy": True}
+
+    @pytest.mark.unit
+    async def test_pt_get_departures(self, mcp):
+        fn = await get_tool(mcp, "pt_get_departures")
+        result = await fn.fn("pt-Metro-Porto_5726", limit=5)
+        assert result == {"dummy": True}
+
+    @pytest.mark.unit
+    async def test_pt_nearby_stations(self, mcp):
+        fn = await get_tool(mcp, "pt_nearby_stations")
+        result = await fn.fn(41.15228, -8.609299, results=8)
+        assert result == [GEOCODE[0]]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -5,5 +5,6 @@ from .ch import register_ch_tools
 from .uk import register_uk_tools
 from .be import register_be_tools
 from .vbb import register_vbb_tools
+from .pt import register_pt_tools
 
-__all__ = ['register_ch_tools', 'register_uk_tools', 'register_be_tools', 'register_vbb_tools']
+__all__ = ['register_ch_tools', 'register_uk_tools', 'register_be_tools', 'register_vbb_tools', 'register_pt_tools']

--- a/tools/pt.py
+++ b/tools/pt.py
@@ -1,0 +1,240 @@
+# tools/pt.py
+"""
+Portugal public transport tools for MCP server
+Uses Transitous (api.transitous.org), a MOTIS instance routing over ingested GTFS feeds.
+
+Coverage is scoped to the Lisbon and Porto metro areas:
+- Lisbon: Metro Lisboa, Carris, Carris Metropolitana, CP suburban
+- Porto: Metro do Porto, STCP
+
+Provides:
+- pt_search_stations: find stops by name (Portugal only)
+- pt_search_connections: plan a trip A -> B
+- pt_get_departures: departure board for a stop
+- pt_nearby_stations: find stops near coordinates
+
+No authentication required.
+"""
+
+import logging
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import Any, Dict, List, Optional
+from typing_extensions import Annotated
+from pydantic import Field
+
+from core.base import fetch_json, validate_station_name, TransportAPIError, format_time_for_api
+from config import PT_BASE_URL
+
+logger = logging.getLogger(__name__)
+
+# both metro areas share the same zone
+PT_TZ = ZoneInfo("Europe/Lisbon")
+
+
+def _to_iso(date: Optional[str], time: Optional[str]) -> Optional[str]:
+    """Combine date (YYYY-MM-DD) and time (HH:MM) into an rfc3339 string.
+
+    motis rejects naive timestamps so we attach the Lisbon offset. missing parts
+    fall back to today / midnight. returns None when nothing was given (motis
+    then defaults to now).
+    """
+    if not date and not time:
+        return None
+
+    now = datetime.now(PT_TZ)
+    if date:
+        y, m, d = (int(p) for p in date.split("-"))
+    else:
+        y, m, d = now.year, now.month, now.day
+
+    hh, mm = (0, 0)
+    if time:
+        hh, mm = (int(p) for p in format_time_for_api(time).split(":"))
+
+    local = datetime(y, m, d, hh, mm, tzinfo=PT_TZ)
+    return local.isoformat()
+
+
+def _pt_only(hits: List[Dict[str, Any]], limit: int) -> List[Dict[str, Any]]:
+    """Keep Portuguese hits only and trim. geocode is global so we filter here."""
+    return [h for h in hits if h.get("country") == "PT"][:limit]
+
+
+def register_pt_tools(mcp):
+    """Register Portugal (Lisbon + Porto) transport tools with the MCP server."""
+
+    @mcp.tool(
+        name="pt_search_stations",
+        description=(
+            "Search for stops/stations in Portugal by name. "
+            "Covers the Lisbon and Porto metro areas (metro, buses, trams, suburban rail) "
+            "via Transitous. Returns stop id, name and coordinates - use the id with "
+            "pt_search_connections and pt_get_departures."
+        ),
+    )
+    async def pt_search_stations(
+        query: Annotated[
+            str,
+            Field(description="Station/stop search query. Example: 'Trindade'", min_length=1),
+        ],
+        limit: Annotated[
+            Optional[int],
+            Field(description="Max number of results (default 10).", ge=1, le=50),
+        ] = 10,
+    ) -> List[Dict[str, Any]]:
+        query_clean = validate_station_name(query)
+
+        params = {
+            "text": query_clean,
+            "type": "STOP",
+        }
+
+        try:
+            logger.info("Searching PT stations: %s", query_clean)
+            hits = await fetch_json(f"{PT_BASE_URL}/geocode", params)
+            return _pt_only(hits, int(limit or 10))
+        except TransportAPIError as e:
+            logger.error("PT station search failed: %s", e)
+            raise
+
+    @mcp.tool(
+        name="pt_search_connections",
+        description=(
+            "Plan a public transport connection between two points in the Lisbon or Porto "
+            "metro area. Origin and destination are either stop ids (from pt_search_stations) "
+            "or 'lat,lon' coordinates. Returns itineraries with legs, lines, times and transfers."
+        ),
+    )
+    async def pt_search_connections(
+        origin: Annotated[
+            str,
+            Field(description="Origin stop id or 'lat,lon'. Example: 'pt-Metro-Lisboa_MP'", min_length=1),
+        ],
+        destination: Annotated[
+            str,
+            Field(description="Destination stop id or 'lat,lon'. Example: 'pt-Metro-Lisboa_BC'", min_length=1),
+        ],
+        limit: Annotated[
+            Optional[int],
+            Field(description="Max number of itineraries (default 4).", ge=1, le=10),
+        ] = 4,
+        date: Annotated[
+            Optional[str],
+            Field(description="Date in YYYY-MM-DD format (optional)."),
+        ] = None,
+        time: Annotated[
+            Optional[str],
+            Field(description="Time in HH:MM format (optional)."),
+        ] = None,
+        is_arrival_time: Annotated[
+            Optional[bool],
+            Field(description="If true, interpret date/time as arrival time (default false)."),
+        ] = False,
+    ) -> Dict[str, Any]:
+        origin_clean = origin.strip()
+        destination_clean = destination.strip()
+        if not origin_clean or not destination_clean:
+            raise ValueError("Origin and destination cannot be empty")
+
+        params: Dict[str, Any] = {
+            "fromPlace": origin_clean,
+            "toPlace": destination_clean,
+            "numItineraries": int(limit or 4),
+        }
+
+        when = _to_iso(date, time)
+        if when:
+            params["time"] = when
+        if is_arrival_time:
+            params["arriveBy"] = "true"
+
+        try:
+            logger.info("Planning PT connection: %s -> %s", origin_clean, destination_clean)
+            return await fetch_json(f"{PT_BASE_URL}/plan", params)
+        except TransportAPIError as e:
+            logger.error("PT connection search failed: %s", e)
+            raise
+
+    @mcp.tool(
+        name="pt_get_departures",
+        description=(
+            "Get the departure board for a stop in the Lisbon or Porto metro area. "
+            "Needs a stop id from pt_search_stations. Returns upcoming departures with "
+            "line, headsign and real-time times."
+        ),
+    )
+    async def pt_get_departures(
+        stop_id: Annotated[
+            str,
+            Field(description="Stop id. Example: 'pt-Metro-Porto_5726' for Trindade", min_length=1),
+        ],
+        limit: Annotated[
+            Optional[int],
+            Field(description="Max departures to return (default 10).", ge=1, le=50),
+        ] = 10,
+        time: Annotated[
+            Optional[str],
+            Field(description="Date/time as rfc3339 (optional). Default: now."),
+        ] = None,
+    ) -> Dict[str, Any]:
+        stop_id_clean = stop_id.strip()
+        if not stop_id_clean:
+            raise ValueError("Stop ID cannot be empty")
+
+        params: Dict[str, Any] = {
+            "stopId": stop_id_clean,
+            "n": int(limit or 10),
+        }
+
+        if time:
+            params["time"] = time.strip()
+
+        try:
+            logger.info("Getting PT departures for stop: %s", stop_id_clean)
+            return await fetch_json(f"{PT_BASE_URL}/stoptimes", params)
+        except TransportAPIError as e:
+            logger.error("PT departures fetch failed: %s", e)
+            raise
+
+    @mcp.tool(
+        name="pt_nearby_stations",
+        description=(
+            "Find stops/stations near coordinates in the Lisbon or Porto metro area. "
+            "Returns the closest stops with id, name and coordinates."
+        ),
+    )
+    async def pt_nearby_stations(
+        latitude: Annotated[
+            float,
+            Field(description="Latitude in decimal degrees. Example: 41.15228", ge=-90, le=90),
+        ],
+        longitude: Annotated[
+            float,
+            Field(description="Longitude in decimal degrees. Example: -8.609299", ge=-180, le=180),
+        ],
+        results: Annotated[
+            Optional[int],
+            Field(description="Max number of results (default 8).", ge=1, le=50),
+        ] = 8,
+    ) -> List[Dict[str, Any]]:
+        # reverse-geocode wants "lat,lon"
+        params = {
+            "place": f"{float(latitude)},{float(longitude)}",
+            "type": "STOP",
+        }
+
+        try:
+            logger.info("Finding PT stations near provided coordinates")
+            hits = await fetch_json(f"{PT_BASE_URL}/reverse-geocode", params)
+            return _pt_only(hits, int(results or 8))
+        except TransportAPIError as e:
+            logger.error("PT nearby stations search failed: %s", e)
+            raise
+
+    return [
+        pt_search_stations,
+        pt_search_connections,
+        pt_get_departures,
+        pt_nearby_stations,
+    ]

--- a/tools/pt.py
+++ b/tools/pt.py
@@ -14,6 +14,11 @@ Provides:
 - pt_nearby_stations: find stops near coordinates
 
 No authentication required.
+
+Attribution: data is provided by Transitous (https://transitous.org), a best-effort,
+volunteer-run service built on openly ingested GTFS feeds. Keep the attribution visible
+to users and follow the usage policy at https://transitous.org/api/ (see also
+https://transitous.org/sources/ for underlying feed/OpenStreetMap attribution).
 """
 
 import logging
@@ -30,6 +35,12 @@ logger = logging.getLogger(__name__)
 
 # both metro areas share the same zone
 PT_TZ = ZoneInfo("Europe/Lisbon")
+
+# surfaced to users in each tool description; transitous wants attribution kept visible
+_ATTRIBUTION = (
+    "Data via Transitous (https://transitous.org), a best-effort, volunteer-run service; "
+    "usage policy: https://transitous.org/api/."
+)
 
 
 def _to_iso(date: Optional[str], time: Optional[str]) -> Optional[str]:
@@ -70,7 +81,8 @@ def register_pt_tools(mcp):
             "Search for stops/stations in Portugal by name. "
             "Covers the Lisbon and Porto metro areas (metro, buses, trams, suburban rail) "
             "via Transitous. Returns stop id, name and coordinates - use the id with "
-            "pt_search_connections and pt_get_departures."
+            "pt_search_connections and pt_get_departures. "
+            + _ATTRIBUTION
         ),
     )
     async def pt_search_stations(
@@ -103,7 +115,8 @@ def register_pt_tools(mcp):
         description=(
             "Plan a public transport connection between two points in the Lisbon or Porto "
             "metro area. Origin and destination are either stop ids (from pt_search_stations) "
-            "or 'lat,lon' coordinates. Returns itineraries with legs, lines, times and transfers."
+            "or 'lat,lon' coordinates. Returns itineraries with legs, lines, times and transfers. "
+            + _ATTRIBUTION
         ),
     )
     async def pt_search_connections(
@@ -161,7 +174,8 @@ def register_pt_tools(mcp):
         description=(
             "Get the departure board for a stop in the Lisbon or Porto metro area. "
             "Needs a stop id from pt_search_stations. Returns upcoming departures with "
-            "line, headsign and real-time times."
+            "line, headsign and real-time times. "
+            + _ATTRIBUTION
         ),
     )
     async def pt_get_departures(
@@ -201,7 +215,8 @@ def register_pt_tools(mcp):
         name="pt_nearby_stations",
         description=(
             "Find stops/stations near coordinates in the Lisbon or Porto metro area. "
-            "Returns the closest stops with id, name and coordinates."
+            "Returns the closest stops with id, name and coordinates. "
+            + _ATTRIBUTION
         ),
     )
     async def pt_nearby_stations(


### PR DESCRIPTION
hey! first off, thanks for this project, it's really clean and easy to extend.
i wanted to use it for my own trips around Lisbon and Porto, so i went ahead and
added a Portugal provider.

### data source
i went with Transitous (api.transitous.org), the free no-auth MOTIS instance that
routes over ingested GTFS feeds. before building anything i checked that it
actually ingests the Lisbon and Porto metro-area feeds (Metro Lisboa, Carris,
Carris Metropolitana, CP suburban, Metro do Porto, STCP) and curled real
responses. since it does routing + geocoding + stop times, it maps cleanly onto
the same shape as the CH provider, instead of the departures-only native APIs.

### what's in here
- `tools/pt.py` with `register_pt_tools(mcp)` and four tools mirroring `ch.py`:
  - `pt_search_stations`
  - `pt_search_connections`
  - `pt_get_departures`
  - `pt_nearby_stations`
- registered in `server.py`
- `test/test_pt.py` mirroring the existing tests (HTTP layer mocked, no live calls)
- README updated to list Portugal (Lisbon + Porto)

### notes
- no new dependencies, reuses the `core/base.py` helpers
- no API key needed
- scope is intentionally limited to the Lisbon + Porto metro areas, documented in
  the tool descriptions and README. geocode results are filtered to PT, and i left
  a TODO to tighten the scoping further.
- `make lint` and `make test` pass (20 tests total)

happy to tweak naming or scope if you'd prefer something different. thanks again!
